### PR TITLE
add public nodes setup with self-signed certificate + add tf-unlock cmd.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ credentials.json
 config/*
 !config/*template*
 !config/*sample*
+log/*

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ There are two ways of using this repository:
   * In ansible, the templates are sometimes not overwritten on the remote if the file already exists. Then you need to
     manually remove the file before syncing. This is not as documented by Ansible...
   * The node on the same resource cannot change from collator to non-collator without purging the node's db.
-    
 
 ## Structure
 
@@ -51,7 +50,6 @@ proxy.
 * Public Nodes (are not run as collators):
   * also do the above.
   * set up an ssl reverse proxy with nginx for the websocket-rpc interface.
-
 
 The setup also configures a firewall in which the default p2p port is closed for
 incoming connections and only the proxy port is open.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![CircleCI](https://circleci.com/gh/w3f/polkadot-secure-validator.svg?style=svg)](https://circleci.com/gh/w3f/polkadot-secure-validator)
 
-# Polkadot Validator Setup
+# Polkadot Collator Setup
 
-This repo describes a potential setup for a Polkadot or Kusama validator that aims to
+This repo describes a potential setup for a Polkadot or Kusama integritee-parachain setup that aims to
 prevent some types of potential attacks at the TCP layer and below.
 The [Workflow](#workflow) section describes the [Platform Layer](#platform-layer)
 and the [Application Layer](#application-layer) in more detail.
@@ -50,12 +50,12 @@ incoming connections and only the proxy port is open.
 
 ## Workflow
 
-The secure validator setup is structured in two layers, an underlying platform
+The secure collator setup is structured in two layers, an underlying platform
 and the applications that run on top of it.
 
 ### Platform Layer
 
-Validators are created using the terraform modules located at [terraform](/terraform)
+Collators are created using the terraform modules located at [terraform](/terraform)
 directory. We have created code for several providers but it is possible to add new
 ones, please reach out if you are interested in any provider currently not available.
 
@@ -64,10 +64,10 @@ infrastructure for adding firewall rules to protect the nodes.
 
 ### Application Layer
 
-This is done through the ansible playbook and polkadot-validator role located at
+This is done through the ansible playbook and polkadot-collator role located at
 [ansible](/ansible), basically the role performs these actions:
 
-* Software firewall setup, for the validator we only allow the proxy, SSH and, if
+* Software firewall setup, for the collator we only allow the proxy, SSH and, if
 enabled, node-exporter ports.
 * Configure journald to tune log storage.
 * Create polkadot user and group.
@@ -78,12 +78,12 @@ enabled, node-exporter ports.
 
 # Note about upgrades from the sentries setup
 
-The current version of polkadot-secure-validator doesn't allow to create and configure
+The current version of polkadot-secure-collator doesn't allow to create and configure
 sentry nodes. Although the terraform files and ansible roles of this latest version
-can be applied on setups created with previous versions, the validators would be configured
+can be applied on setups created with previous versions, the collators would be configured
 to work without sentries and to connect to the network using the local reverse proxy instead.
 
 If you created the sentries with a previous version of this tool through terraform following
 the complete workflow, then they will not be deleted automatically when running this new version.
-In short, the old sentries will no longer be used by the validators and it will be up to you to
+In short, the old sentries will no longer be used by the collators and it will be up to you to
 remove them manually.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ There are two ways of using this repository:
 
   See the [Ansible Guide](GUIDE_ANSIBLE.md) for more.
 
+### Pitfalls
+  * There is the OS firewall, but the is also the resource's firewall (at least for GCP). If access from the outside
+    is needed, both firewalls need to configured.
+  * In ansible the templates are sometimes not overwritten on the remote if the file already exists. Then you need to
+    manually remove the file before syncing. This is not as documented by Ansible...
+  * The node on the same resource cannot change from collator to non-collator without purging the db.
+    
+
 ## Structure
 
 The secure setup is composed of one or more node that run with a local

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ There are two ways of using this repository:
   See the [Ansible Guide](GUIDE_ANSIBLE.md) for more.
 
 ### Pitfalls
-  * There is the OS firewall, but the is also the resource's firewall (at least for GCP). If access from the outside
+  * There is the OS firewall, but there is also the resource's firewall (at least for GCP). If access from the outside
     is needed, both firewalls need to configured.
-  * In ansible the templates are sometimes not overwritten on the remote if the file already exists. Then you need to
+  * In ansible, the templates are sometimes not overwritten on the remote if the file already exists. Then you need to
     manually remove the file before syncing. This is not as documented by Ansible...
-  * The node on the same resource cannot change from collator to non-collator without purging the db.
+  * The node on the same resource cannot change from collator to non-collator without purging the node's db.
     
 
 ## Structure

--- a/README.md
+++ b/README.md
@@ -32,12 +32,18 @@ There are two ways of using this repository:
 
 ## Structure
 
-The secure validator setup is composed of one or more validators that run with a local
-instance of NGINX as a reverse TCP proxy in front of them. The validators are instructed to:
-* advertise themselves with the public IP of the node and the port where the
+The secure setup is composed of one or more node that run with a local
+instance of NGINX as a reverse TCP proxy in front of them. The nodes are either run as:
+
+* Collators:
+  * advertise themselves with the public p2p IP of the node and the port where the
 reverse proxy is listening.
-* bind to the localhost interface, so that they only allow incoming connections from the
+  * bind to the localhost interface, so that they only allow incoming connections from the
 proxy.
+* Public Nodes (are not run as collators):
+  * also do the above.
+  * set up an ssl reverse proxy with nginx for the websocket-rpc interface.
+
 
 The setup also configures a firewall in which the default p2p port is closed for
 incoming connections and only the proxy port is open.

--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -7,20 +7,20 @@
     wait_for_connection:
 
 - name: collator
-  hosts: collator
+  hosts: collator,publicNode
   become: yes
   roles:
   - polkadot-collator
 
 - name: nginx-auth
-  hosts: collator
+  hosts: collator,publicNode
   become: yes
   strategy: free
   roles:
   - nginx-auth
 
 - name: node-exporter
-  hosts: collator
+  hosts: collator,publicNode
   become: yes
   strategy: free
   roles:

--- a/ansible/roles/polkadot-collator/defaults/main.yml
+++ b/ansible/roles/polkadot-collator/defaults/main.yml
@@ -11,3 +11,6 @@ polkadot_network_id: "ksmcc3"
 subkey_binary_url: 'https://github.com/w3f/substrate/releases/download/e0f3fa/subkey'
 subkey_binary_checksum: 'sha256:f74a06442e76c3bb97d27a168b9710ef062ae5640ad82e7d42b8fb613f8be9d9'
 build_dir: '/tmp'
+main_domain_name: integritee.parachain.org
+all_domain_names: integritee.parachain.org
+letsencrypt_email: hello@integritee.network

--- a/ansible/roles/polkadot-collator/defaults/main.yml
+++ b/ansible/roles/polkadot-collator/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # defaults file for polkadot-collator
 proxy_port: 80
+proxy_wss_port: 443
 relaychain_p2p_port: 30333
 parachain_p2p_port: 30334
 relaychain_ws_port: 9944

--- a/ansible/roles/polkadot-collator/defaults/main.yml
+++ b/ansible/roles/polkadot-collator/defaults/main.yml
@@ -11,6 +11,8 @@ polkadot_network_id: "ksmcc3"
 subkey_binary_url: 'https://github.com/w3f/substrate/releases/download/e0f3fa/subkey'
 subkey_binary_checksum: 'sha256:f74a06442e76c3bb97d27a168b9710ef062ae5640ad82e7d42b8fb613f8be9d9'
 build_dir: '/tmp'
-main_domain_name: integritee.parachain.org
-all_domain_names: integritee.parachain.org
+main_domain_name: www.integritee.network
 letsencrypt_email: hello@integritee.network
+self_signed_certs:
+  - key: /etc/ssl/private/server.key
+    cert: /etc/ssl/certs/server.crt

--- a/ansible/roles/polkadot-collator/tasks/firewall.yml
+++ b/ansible/roles/polkadot-collator/tasks/firewall.yml
@@ -54,7 +54,23 @@
 - name: open rpc proxy port (publicNode)
   command: ufw allow {{ proxy_wss_port }}/tcp
   when:
-    - is_public_node|default(false)|bool or isPublicNode|default(false)|bool
+    - is_public|default(false)|bool
+
+- name: close rpc proxy port (publicNode)
+  command: ufw deny {{ proxy_wss_port }}/tcp
+  when:
+    - not is_public|default(false)|bool
+
+# port 80 is needed for certbot
+- name: open port 80 (publicNode)
+  command: ufw allow 80/tcp
+  when:
+    - is_public|default(false)|bool
+
+- name: close port 80 (publicNode)
+  command: ufw deny 80/tcp
+  when:
+    - not is_public|default(false)|bool
 
 - name: enable firewall
   shell: |

--- a/ansible/roles/polkadot-collator/tasks/firewall.yml
+++ b/ansible/roles/polkadot-collator/tasks/firewall.yml
@@ -51,6 +51,11 @@
     - enable_reverse_proxy|default(false)|bool or enableReverseProxy|default(false)|bool
     - not ufw_status_result.stdout is search(proxy_port ~ "/tcp.*ALLOW IN.*Anywhere")
 
+- name: open rpc proxy port (publicNode)
+  command: ufw allow {{ proxy_wss_port }}/tcp
+  when:
+    - is_public_node|default(false)|bool or isPublicNode|default(false)|bool
+
 - name: enable firewall
   shell: |
     set -o pipefail

--- a/ansible/roles/polkadot-collator/tasks/letsencrypt.yml
+++ b/ansible/roles/polkadot-collator/tasks/letsencrypt.yml
@@ -48,7 +48,7 @@
 - name: Install nginx site for node
   template:
     src: proxy.public.node.conf.j2
-    dest: /etc/nginx/sites-enabled/node
+    dest: /etc/nginx/sites-enabled//etc/nginx/sites-enabled/integritee-node.conf
 
 - name: Reload nginx to activate specified site
   service:

--- a/ansible/roles/polkadot-collator/tasks/letsencrypt.yml
+++ b/ansible/roles/polkadot-collator/tasks/letsencrypt.yml
@@ -45,10 +45,10 @@
   args:
     creates: /etc/nginx/dhparams.pem
 
-- name: Install nginx site for {{ main_domain_name }}
+- name: Install nginx site for node
   template:
-    src: proxy.public.node.conf.js
-    dest: /etc/nginx/sites-enabled/{{ main_domain_name }}
+    src: proxy.public.node.conf.j2
+    dest: /etc/nginx/sites-enabled/node
 
 - name: Reload nginx to activate specified site
   service:

--- a/ansible/roles/polkadot-collator/tasks/letsencrypt.yml
+++ b/ansible/roles/polkadot-collator/tasks/letsencrypt.yml
@@ -1,0 +1,62 @@
+# tasks file for letsencrypt
+- name: Install Python simplejson
+  apt:
+    pkg: python-simplejson
+    state: present
+    update_cache: true
+
+- name: install letsencrypt
+  apt:
+    name: letsencrypt
+    state: latest
+
+- name: create letsencrypt directory
+  file:
+    name: /var/www/letsencrypt
+    state: directory
+
+- name: Remove default nginx config
+  file:
+    name: /etc/nginx/sites-enabled/default
+    state: absent
+
+#- name: Install system nginx config
+#  template:
+#    src: templates/nginx.conf.j2
+#    dest: /etc/nginx/nginx.conf
+
+- name: Install nginx site for letsencrypt requests
+  template:
+    src: templates/letsencrypt-requests.j2
+    dest: /etc/nginx/sites-enabled/http
+
+- name: Reload nginx to activate letsencrypt site
+  service:
+    name: nginx
+    state: restarted
+
+- name: Create letsencrypt certificate
+  shell: letsencrypt certonly -n --webroot -w /var/www/letsencrypt -m {{ letsencrypt_email }} --agree-tos -d {{ main_domain_name }}
+  args:
+    creates: /etc/letsencrypt/live/{{ main_domain_name }}
+
+- name: Generate dhparams
+  shell: openssl dhparam -out /etc/nginx/dhparams.pem 2048
+  args:
+    creates: /etc/nginx/dhparams.pem
+
+- name: Install nginx site for {{ main_domain_name }}
+  template:
+    src: proxy.public.node.conf.js
+    dest: /etc/nginx/sites-enabled/{{ main_domain_name }}
+
+- name: Reload nginx to activate specified site
+  service:
+    name: nginx
+    state: restarted
+
+- name: Add letsencrypt cronjob for cert renewal
+  cron:
+    name: letsencrypt_renewal
+    special_time: weekly
+    job: letsencrypt --renew certonly -n --webroot -w /var/www/letsencrypt -m {{ letsencrypt_email }} --agree-tos {{ all_domain_names | map('regex_replace', '^(.*)$', '-d \\1') | join(' ')}} && service nginx reload

--- a/ansible/roles/polkadot-collator/tasks/main.yml
+++ b/ansible/roles/polkadot-collator/tasks/main.yml
@@ -12,6 +12,11 @@
 - name: proxy setup
   import_tasks: proxy.yml
 
+- name: letsencrypt and ssl reverse proxy setup
+  import_tasks: letsencrypt.yml
+  when:
+    - is_public|default(false)|bool
+
 - name: service setup
   import_tasks: service.yml
 

--- a/ansible/roles/polkadot-collator/tasks/main.yml
+++ b/ansible/roles/polkadot-collator/tasks/main.yml
@@ -12,8 +12,14 @@
 - name: proxy setup
   import_tasks: proxy.yml
 
-- name: letsencrypt and ssl reverse proxy setup
-  import_tasks: letsencrypt.yml
+# Todo: certbot does not work, use self-signed for now
+#- name: letsencrypt and ssl reverse proxy setup
+#  import_tasks: letsencrypt.yml
+#  when:
+#    - is_public|default(false)|bool
+
+- name: self-signed ssl reverse proxy setup
+  import_tasks: self_signed_proxy.yml
   when:
     - is_public|default(false)|bool
 

--- a/ansible/roles/polkadot-collator/tasks/proxy.yml
+++ b/ansible/roles/polkadot-collator/tasks/proxy.yml
@@ -26,6 +26,14 @@
     path: /etc/nginx/sites-enabled/default
     state: absent
 
+#- name: letsencrypt setup and ssl reverse proxy
+#  template:
+#    src: proxy.public.node.conf.j2
+#    dest: /etc/nginx/streams-enabled/public-node.conf
+#    mode: 0600
+#  when:
+#    - is_public|default(false)|bool
+
 - name: create proxy service file
   template:
     src: proxy.conf.j2

--- a/ansible/roles/polkadot-collator/tasks/proxy.yml
+++ b/ansible/roles/polkadot-collator/tasks/proxy.yml
@@ -26,14 +26,6 @@
     path: /etc/nginx/sites-enabled/default
     state: absent
 
-#- name: letsencrypt setup and ssl reverse proxy
-#  template:
-#    src: proxy.public.node.conf.j2
-#    dest: /etc/nginx/streams-enabled/public-node.conf
-#    mode: 0600
-#  when:
-#    - is_public|default(false)|bool
-
 - name: create proxy service file
   template:
     src: proxy.conf.j2

--- a/ansible/roles/polkadot-collator/tasks/self_signed_proxy.yml
+++ b/ansible/roles/polkadot-collator/tasks/self_signed_proxy.yml
@@ -1,0 +1,27 @@
+
+- name: Remove default nginx config
+  file:
+    name: /etc/nginx/sites-enabled/default
+    state: absent
+
+- name: Create self-signed certificate, if configured.
+  command: >
+    openssl req -x509 -nodes -subj '/O=Integritee Node' -days 365
+    -newkey rsa:4096 -sha256 -keyout {{ item.key }} -out {{ item.cert }}
+    creates={{ item.cert }}
+  with_items: "{{ self_signed_certs }}"
+
+- name: Generate dhparams
+  shell: openssl dhparam -out /etc/nginx/dhparams.pem 2048
+  args:
+    creates: /etc/nginx/dhparams.pem
+
+- name: Install nginx site for node
+  template:
+    src: proxy.public.node.conf.j2
+    dest: /etc/nginx/sites-enabled/node
+
+- name: Reload nginx to activate specified site
+  service:
+    name: nginx
+    state: restarted

--- a/ansible/roles/polkadot-collator/tasks/self_signed_proxy.yml
+++ b/ansible/roles/polkadot-collator/tasks/self_signed_proxy.yml
@@ -4,7 +4,7 @@
     name: /etc/nginx/sites-enabled/default
     state: absent
 
-- name: Create self-signed certificate, if configured.
+- name: Create self-signed certificate
   command: >
     openssl req -x509 -nodes -subj '/O=Integritee Node' -days 365
     -newkey rsa:4096 -sha256 -keyout {{ item.key }} -out {{ item.cert }}

--- a/ansible/roles/polkadot-collator/tasks/self_signed_proxy.yml
+++ b/ansible/roles/polkadot-collator/tasks/self_signed_proxy.yml
@@ -19,7 +19,7 @@
 - name: Install nginx site for node
   template:
     src: proxy.public.node.conf.j2
-    dest: /etc/nginx/sites-enabled/node
+    dest: /etc/nginx/sites-enabled/integritee-node.conf
 
 - name: Reload nginx to activate specified site
   service:

--- a/ansible/roles/polkadot-collator/templates/collator.service.j2
+++ b/ansible/roles/polkadot-collator/templates/collator.service.j2
@@ -9,6 +9,7 @@
 {% set additional_flags = hostvars[inventory_hostname].additional_flags|default(None) %}
 {% set is_collator = hostvars[inventory_hostname].is_collator|default(false) %}
 {% set is_public= hostvars[inventory_hostname].is_public|default(false) %}
+{% set ip_address = hostvars[inventory_hostname].ip_address |default(None) %}
 
 {% set additional_common_flags = hostvars[inventory_hostname].parachain_additional_common_flags|default(None) %}
 {% set additional_collator_flags = hostvars[inventory_hostname].parachain_additional_collator_flags|default(None) %}
@@ -72,6 +73,9 @@ ExecStart=/usr/local/bin/collator \
   {% endif %}
   {% if is_collator is sameas true and additional_collator_flags is not none and additional_collator_flags|length %}
   {{ additional_collator_flags }} \
+  {% endif %}
+  {% if is_public is sameas true %}
+  --rpc-cors all \
   {% endif %}
   {% if is_public is sameas true and additional_public_flags is not none and additional_public_flags|length %}
   {{ additional_public_flags }} \

--- a/ansible/roles/polkadot-collator/templates/collator.service.j2
+++ b/ansible/roles/polkadot-collator/templates/collator.service.j2
@@ -7,6 +7,9 @@
 {% set logging_filter = hostvars[inventory_hostname].logging_filter|default(None) %}
 {% set base_path = hostvars[inventory_hostname].base_path|default(None) %}
 {% set additional_flags = hostvars[inventory_hostname].additional_flags|default(None) %}
+{% set is_collator = hostvars[inventory_hostname].is_collator|default(false) %}
+{% set is_public= hostvars[inventory_hostname].is_public|default(false) %}
+
 {# ## Legacy/deprecated flags #}
 {% if node_name is none %}
   {% set node_name = hostvars[inventory_hostname].nodeName|default(None) %}
@@ -65,10 +68,10 @@ ExecStart=/usr/local/bin/collator \
   {% if additionalCommonFlags is not none and additionalCommonFlags|length %}
   {{ additionalCommonFlags }} \
   {% endif %}
-  {% if additionalCollatorFlags is not none and additionalCollatorFlags|length %}
+  {% if is_collator is sameas true and additionalCollatorFlags is not none and additionalCollatorFlags|length %}
   {{ additionalCollatorFlags }} \
   {% endif %}
-  {% if additionalPublicFlags is not none and additionalPublicFlags|length %}
+  {% if is_public is sameas true and additionalPublicFlags is not none and additionalPublicFlags|length %}
   {{ additionalPublicFlags }} \
   {% endif %}
   {# --- #}

--- a/ansible/roles/polkadot-collator/templates/collator.service.j2
+++ b/ansible/roles/polkadot-collator/templates/collator.service.j2
@@ -39,6 +39,9 @@ StartLimitIntervalSec=0
 User=polkadot
 Group=polkadot
 ExecStart=/usr/local/bin/collator \
+  {% if is_collator is sameas true %}
+  --collator {{ execution }} \
+  {% endif %}
   {% if execution is not none and execution|length %}
   --execution {{ execution }} \
   {% endif %}

--- a/ansible/roles/polkadot-collator/templates/collator.service.j2
+++ b/ansible/roles/polkadot-collator/templates/collator.service.j2
@@ -20,8 +20,8 @@
 {% if logging_filter is none %}
   {% set logging_filter = hostvars[inventory_hostname].loggingFilter|default(None) %}
 {% endif %}
-{% set additionalCommonFlags = hostvars[inventory_hostname].polkadot_additional_common_flags|default(None) %}
-{% set additionalCollatorFlags = hostvars[inventory_hostname].polkadot_additional_collator_flags|default(None) %}
+{% set additionalCommonFlags = hostvars[inventory_hostname].parachain_additional_common_flags|default(None) %}
+{% set additionalCollatorFlags = hostvars[inventory_hostname].parachain_additional_collator_flags|default(None) %}
 {# --- #}
 [Unit]
 Description=Parachain Collator Node
@@ -68,7 +68,6 @@ ExecStart=/usr/local/bin/collator \
   {{ additionalCollatorFlags }} \
   {% endif %}
   {# --- #}
-  --collator \
   --chain={{ parachain }} \
   --listen-addr=/ip4/127.0.0.1/tcp/{{ parachain_p2p_port }} \
   --rpc-methods=Unsafe \

--- a/ansible/roles/polkadot-collator/templates/collator.service.j2
+++ b/ansible/roles/polkadot-collator/templates/collator.service.j2
@@ -74,6 +74,7 @@ ExecStart=/usr/local/bin/collator \
   {% if is_collator is sameas true and additional_collator_flags is not none and additional_collator_flags|length %}
   {{ additional_collator_flags }} \
   {% endif %}
+  --ws-port {{ parachain_ws_port }} \
   {% if is_public is sameas true %}
   --rpc-cors all \
   {% endif %}
@@ -87,6 +88,7 @@ ExecStart=/usr/local/bin/collator \
   {# --- RELAY CHAIN STUFF #}
   -- --execution wasm \
   --listen-addr=/ip4/127.0.0.1/tcp/{{ relaychain_p2p_port }} \
+  --ws-port {{ relaychain_ws_port }} \
   --prometheus-port=9614
 Restart=always
 RestartSec=60

--- a/ansible/roles/polkadot-collator/templates/collator.service.j2
+++ b/ansible/roles/polkadot-collator/templates/collator.service.j2
@@ -22,6 +22,7 @@
 {% endif %}
 {% set additionalCommonFlags = hostvars[inventory_hostname].parachain_additional_common_flags|default(None) %}
 {% set additionalCollatorFlags = hostvars[inventory_hostname].parachain_additional_collator_flags|default(None) %}
+{% set additionalPublicFlags = hostvars[inventory_hostname].parachain_additional_public_flags|default(None) %}
 {# --- #}
 [Unit]
 Description=Parachain Collator Node
@@ -66,6 +67,9 @@ ExecStart=/usr/local/bin/collator \
   {% endif %}
   {% if additionalCollatorFlags is not none and additionalCollatorFlags|length %}
   {{ additionalCollatorFlags }} \
+  {% endif %}
+  {% if additionalPublicFlags is not none and additionalPublicFlags|length %}
+  {{ additionalPublicFlags }} \
   {% endif %}
   {# --- #}
   --chain={{ parachain }} \

--- a/ansible/roles/polkadot-collator/templates/collator.service.j2
+++ b/ansible/roles/polkadot-collator/templates/collator.service.j2
@@ -10,6 +10,11 @@
 {% set is_collator = hostvars[inventory_hostname].is_collator|default(false) %}
 {% set is_public= hostvars[inventory_hostname].is_public|default(false) %}
 
+{% set additional_common_flags = hostvars[inventory_hostname].parachain_additional_common_flags|default(None) %}
+{% set additional_collator_flags = hostvars[inventory_hostname].parachain_additional_collator_flags|default(None) %}
+{% set additional_public_flags = hostvars[inventory_hostname].parachain_additional_public_flags|default(None) %}
+
+
 {# ## Legacy/deprecated flags #}
 {% if node_name is none %}
   {% set node_name = hostvars[inventory_hostname].nodeName|default(None) %}
@@ -23,9 +28,6 @@
 {% if logging_filter is none %}
   {% set logging_filter = hostvars[inventory_hostname].loggingFilter|default(None) %}
 {% endif %}
-{% set additionalCommonFlags = hostvars[inventory_hostname].parachain_additional_common_flags|default(None) %}
-{% set additionalCollatorFlags = hostvars[inventory_hostname].parachain_additional_collator_flags|default(None) %}
-{% set additionalPublicFlags = hostvars[inventory_hostname].parachain_additional_public_flags|default(None) %}
 {# --- #}
 [Unit]
 Description=Parachain Collator Node
@@ -65,14 +67,14 @@ ExecStart=/usr/local/bin/collator \
   {{ additional_flags }} \
   {% endif %}
   {# --- DEPRECATED --- #}
-  {% if additionalCommonFlags is not none and additionalCommonFlags|length %}
-  {{ additionalCommonFlags }} \
+  {% if additional_common_flags is not none and additional_common_flags|length %}
+  {{ additional_common_flags }} \
   {% endif %}
-  {% if is_collator is sameas true and additionalCollatorFlags is not none and additionalCollatorFlags|length %}
-  {{ additionalCollatorFlags }} \
+  {% if is_collator is sameas true and additional_collator_flags is not none and additional_collator_flags|length %}
+  {{ additional_collator_flags }} \
   {% endif %}
-  {% if is_public is sameas true and additionalPublicFlags is not none and additionalPublicFlags|length %}
-  {{ additionalPublicFlags }} \
+  {% if is_public is sameas true and additional_public_flags is not none and additional_public_flags|length %}
+  {{ additional_public_flags }} \
   {% endif %}
   {# --- #}
   --chain={{ parachain }} \

--- a/ansible/roles/polkadot-collator/templates/letsencrypt-requests.j2
+++ b/ansible/roles/polkadot-collator/templates/letsencrypt-requests.j2
@@ -1,0 +1,15 @@
+server_tokens off;
+
+server {
+    listen 80 default_server;
+    server_name {{ main_domain_name }};
+
+    location /.well-known/acme-challenge {
+        root /var/www/letsencrypt;
+        try_files $uri $uri/ =404;
+    }
+
+    location / {
+        rewrite ^ https://{{ main_domain_name }}$request_uri? permanent;
+    }
+}

--- a/ansible/roles/polkadot-collator/templates/proxy.conf.j2
+++ b/ansible/roles/polkadot-collator/templates/proxy.conf.j2
@@ -1,5 +1,16 @@
+{% if is_public_node is none %}
+  {% set is_public_node = hostvars[inventory_hostname].isPublicNode|default(false) %}
+{% endif %}
+
 server {
   listen 0.0.0.0:{{ proxy_port }};
   proxy_pass localhost:{{ relaychain_p2p_port }};
   proxy_pass localhost:{{ parachain_p2p_port }};
 }
+
+{% if is_public_node %}
+server {
+  listen 0.0.0.0:{{ proxy_wss_port }};
+  proxy_pass localhost:{{ parachain_ws_port }};
+}
+{% endif %}

--- a/ansible/roles/polkadot-collator/templates/proxy.conf.j2
+++ b/ansible/roles/polkadot-collator/templates/proxy.conf.j2
@@ -1,6 +1,4 @@
-{% if is_public_node is none %}
-  {% set is_public_node = hostvars[inventory_hostname].isPublicNode|default(false) %}
-{% endif %}
+{% set is_public= hostvars[inventory_hostname].is_public|default(false) %}
 
 server {
   listen 0.0.0.0:{{ proxy_port }};
@@ -8,7 +6,7 @@ server {
   proxy_pass localhost:{{ parachain_p2p_port }};
 }
 
-{% if is_public_node %}
+{% if is_public is sameas true %}
 server {
   listen 0.0.0.0:{{ proxy_wss_port }};
   proxy_pass localhost:{{ parachain_ws_port }};

--- a/ansible/roles/polkadot-collator/templates/proxy.conf.j2
+++ b/ansible/roles/polkadot-collator/templates/proxy.conf.j2
@@ -1,14 +1,9 @@
-{% set is_public= hostvars[inventory_hostname].is_public|default(false) %}
-
 server {
   listen 0.0.0.0:{{ proxy_port }};
   proxy_pass localhost:{{ relaychain_p2p_port }};
-  proxy_pass localhost:{{ parachain_p2p_port }};
 }
 
-{% if is_public is sameas true %}
 server {
-  listen 0.0.0.0:{{ proxy_wss_port }};
-  proxy_pass localhost:{{ parachain_ws_port }};
+  listen 0.0.0.0:{{ proxy_port }};
+  proxy_pass localhost:{{ parachain_p2p_port }};
 }
-{% endif %}

--- a/ansible/roles/polkadot-collator/templates/proxy.public.node.conf.j2
+++ b/ansible/roles/polkadot-collator/templates/proxy.public.node.conf.j2
@@ -1,7 +1,6 @@
 server {
   listen {{ proxy_wss_port }} ssl;
-#  fixme: ipv6 gives invalid host currently
-# listen [::}:{{ proxy_wss_port }} ssl ipv6only=on;
+  listen [::]:{{ proxy_wss_port }} ssl ipv6only=on;
 
   server_name {{ ip_address }};
 
@@ -13,8 +12,7 @@ server {
     #as directory, then fall back to displaying a 404.
     try_files $uri $uri/ =404;
 
-    # Todo: change to parachain port.
-    proxy_pass http://localhost:{{ relaychain_ws_port }};
+    proxy_pass http://localhost:{{ parachain_ws_port }};
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/ansible/roles/polkadot-collator/templates/proxy.public.node.conf.j2
+++ b/ansible/roles/polkadot-collator/templates/proxy.public.node.conf.j2
@@ -1,15 +1,19 @@
-# HTTPS server
-#
 server {
   listen {{ proxy_wss_port }} ssl;
 #  fixme: ipv6 gives invalid host currently
 # listen [::}:{{ proxy_wss_port }} ssl ipv6only=on;
 
-  server_name {{ main_domain_name }};
+  server_name {{ ip_address }};
+
+  root /var/www/html;
+  index index.html index.nginx-debian.html;
 
   location / {
+    #First attempt to serve request as file, then
+    #as directory, then fall back to displaying a 404.
     try_files $uri $uri/ =404;
 
+    # Todo: change to parachain port.
     proxy_pass http://localhost:{{ relaychain_ws_port }};
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header Host $host;

--- a/ansible/roles/polkadot-collator/templates/proxy.public.node.conf.j2
+++ b/ansible/roles/polkadot-collator/templates/proxy.public.node.conf.j2
@@ -20,6 +20,9 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
+
+    access_log /var/log/nginx/{{ main_domain_name }}.access.log;
+    error_log /var/log/nginx/{{ main_domain_name }}.error.log debug;
   }
 
 # Todo: enable when we have figured out how to handle domain

--- a/ansible/roles/polkadot-collator/templates/proxy.public.node.conf.j2
+++ b/ansible/roles/polkadot-collator/templates/proxy.public.node.conf.j2
@@ -1,4 +1,6 @@
 server {
+  # The server is configured according to the guide in: https://wiki.polkadot.network/docs/maintain-wss
+
   listen {{ proxy_wss_port }} ssl;
   listen [::]:{{ proxy_wss_port }} ssl ipv6only=on;
 

--- a/ansible/roles/polkadot-collator/templates/proxy.public.node.conf.j2
+++ b/ansible/roles/polkadot-collator/templates/proxy.public.node.conf.j2
@@ -1,28 +1,42 @@
 # HTTPS server
 #
 server {
-  listen proxy_wss_port ssl default deferred;
+  listen {{ proxy_wss_port }} ssl;
+#  fixme: ipv6 gives invalid host currently
+# listen [::}:{{ proxy_wss_port }} ssl ipv6only=on;
+
   server_name {{ main_domain_name }};
 
-  ssl_certificate         /etc/letsencrypt/live/{{ main_domain_name }}/fullchain.pem;
-  ssl_certificate_key     /etc/letsencrypt/live/{{ main_domain_name }}/privkey.pem;
-  ssl_trusted_certificate /etc/letsencrypt/live/{{ main_domain_name }}/fullchain.pem;
+  location / {
+    try_files $uri $uri/ =404;
 
-  ssl_session_cache shared:SSL:50m;
-  ssl_session_timeout 5m;
-  ssl_stapling on;
-  ssl_stapling_verify on;
+    proxy_pass http://localhost:{{ relaychain_ws_port }};
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  }
+
+# Todo: enable when we have figured out how to handle domain
+#
+#  ssl_certificate         /etc/letsencrypt/live/{{ main_domain_name }}/fullchain.pem;
+#  ssl_certificate_key     /etc/letsencrypt/live/{{ main_domain_name }}/privkey.pem;
+#  ssl_trusted_certificate /etc/letsencrypt/live/{{ main_domain_name }}/fullchain.pem;
+#  ssl_stapling on;
+#  ssl_stapling_verify on;
+
+  ssl_certificate       {{ self_signed_certs.0.cert }};
+  ssl_certificate_key   {{ self_signed_certs.0.key }};
+
+  # config values taken from: https://wiki.polkadot.network/docs/maintain-wss
+  ssl_session_cache shared:SSL:1m;
+  ssl_session_timeout 1440m;
 
   ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-  ssl_ciphers "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";
-
+  ssl_ciphers "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS";
   ssl_dhparam /etc/nginx/dhparams.pem;
   ssl_prefer_server_ciphers on;
-
-  access_log /var/log/nginx/{{ main_domain_name }}.access.log;
-  error_log /var/log/nginx/{{ main_domain_name }}.error.log;
-
-  location / {
-    proxy_pass http://localhost:{{ relaychain_ws_port }};
-  }
 }

--- a/ansible/roles/polkadot-collator/templates/proxy.public.node.conf.j2
+++ b/ansible/roles/polkadot-collator/templates/proxy.public.node.conf.j2
@@ -1,0 +1,28 @@
+# HTTPS server
+#
+server {
+  listen proxy_wss_port ssl default deferred;
+  server_name {{ main_domain_name }};
+
+  ssl_certificate         /etc/letsencrypt/live/{{ main_domain_name }}/fullchain.pem;
+  ssl_certificate_key     /etc/letsencrypt/live/{{ main_domain_name }}/privkey.pem;
+  ssl_trusted_certificate /etc/letsencrypt/live/{{ main_domain_name }}/fullchain.pem;
+
+  ssl_session_cache shared:SSL:50m;
+  ssl_session_timeout 5m;
+  ssl_stapling on;
+  ssl_stapling_verify on;
+
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";
+
+  ssl_dhparam /etc/nginx/dhparams.pem;
+  ssl_prefer_server_ciphers on;
+
+  access_log /var/log/nginx/{{ main_domain_name }}.access.log;
+  error_log /var/log/nginx/{{ main_domain_name }}.error.log;
+
+  location / {
+    proxy_pass http://localhost:{{ relaychain_ws_port }};
+  }
+}

--- a/config/integritee-kusama.json
+++ b/config/integritee-kusama.json
@@ -49,5 +49,23 @@
         "sshUser": "root"
       }
     ]
+  },
+  "publicNodes": {
+    "telemetryUrl": "wss://my.private.telemetry.endpoint",
+    "additionalFlags": "",
+    "loggingFilter": "sync=info,afg=info,babe=info",
+    "nodes": [
+      {
+        "provider": "gcp",
+        "machineType": "e2-standard-2",
+        "count": 2,
+        "image": "2004",
+        "location": "europe-west6",
+        "zone": "europe-west6-a",
+        "projectId": "integritee-kusama",
+        "nodeName": "testnode-gcp",
+        "sshUser": "root"
+      }
+    ]
   }
 }

--- a/config/integritee-kusama.json
+++ b/config/integritee-kusama.json
@@ -24,7 +24,7 @@
   },
   "collators": {
     "telemetryUrl": "wss://my.private.telemetry.endpoint",
-    "additionalFlags": "",
+    "additionalFlags": "--collator",
     "loggingFilter": "sync=info,afg=info,babe=info",
     "nodes": [
       {

--- a/config/integritee-kusama.json
+++ b/config/integritee-kusama.json
@@ -24,7 +24,7 @@
   },
   "collators": {
     "telemetryUrl": "wss://my.private.telemetry.endpoint",
-    "additionalFlags": "--collator",
+    "additionalFlags": "",
     "loggingFilter": "sync=info,afg=info,babe=info",
     "nodes": [
       {

--- a/config/integritee-kusama.json
+++ b/config/integritee-kusama.json
@@ -36,17 +36,8 @@
         "zone": "europe-west6-a",
         "projectId": "integritee-kusama",
         "nodeName": "testnode-gcp",
-        "sshUser": "root"
-      },
-      {
-        "provider": "digitalocean",
-        "machineType": "s-4vcpu-8gb-amd",
-        "count": 1,
-        "image": "ubuntu-20-04-x64",
-        "location": "fra1",
-        "projectId": "integritee-kusama",
-        "nodeName": "testnode-do",
-        "sshUser": "root"
+        "sshUser": "root",
+        "lockId": 1626675552008111
       }
     ]
   },
@@ -58,13 +49,14 @@
       {
         "provider": "gcp",
         "machineType": "e2-standard-2",
-        "count": 2,
+        "count": 1,
         "image": "2004",
         "location": "europe-west6",
         "zone": "europe-west6-a",
         "projectId": "integritee-kusama",
         "nodeName": "testnode-gcp",
-        "sshUser": "root"
+        "sshUser": "root",
+        "lockId": 1626675551993311
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "mocha --reporter spec --recursive",
     "sync": "node . sync",
     "clean": "node . clean",
+    "unlock": "node . unlock",
     "plan": "node . plan",
     "restore-db": "node . restore-db",
     "rotate-keys": "node . rotate-keys",

--- a/scripts/yarnSyncIntegriteeKusama.sh
+++ b/scripts/yarnSyncIntegriteeKusama.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+# simply executes yarn sync with our integritee config and pipe the output to a log file
+# because there is a lot of output when executing the cmd.
+
+yarn sync -c config/integritee-kusama.json 2>&1 | tee ./log/yarn_sync.log

--- a/scripts/yarnSyncIntegriteeKusama.sh
+++ b/scripts/yarnSyncIntegriteeKusama.sh
@@ -4,4 +4,7 @@ set -euo pipefail
 # simply executes yarn sync with our integritee config and pipe the output to a log file
 # because there is a lot of output when executing the cmd.
 
+eval `ssh-agent`
+ssh-add ~/.ssh/intgeritee_rsa
+
 yarn sync -c config/integritee-kusama.json 2>&1 | tee ./log/yarn_sync.log

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ const sync = require('./lib/actions/sync');
 const plan = require('./lib/actions/plan');
 const version = require('./lib/version');
 const updateBinary = require('./lib/actions/updateBinary');
+const unlock = require('./lib/actions/unlock');
 const restoreDB = require('./lib/actions/restoreDB');
 const rotateKeys = require('./lib/actions/rotateKeys');
 
@@ -31,6 +32,12 @@ program
   .action(clean.do);
 
 program
+  .command('unlock')
+  .description('Releases the tf lock. Only needed when a tf process unexpectedly exits.')
+  .option('-c, --config [path]', 'Path to config file.', './config/main.json')
+  .action(unlock.do);
+
+program
   .command('plan')
   .description('Shows changes in the infrastructure layer that would be performed by sync.')
   .option('-c, --config [path]', 'Path to config file.', './config/main.json')
@@ -46,13 +53,13 @@ program
   .command('restore-db')
   .description('Restore the nodes DB.')
   .option('-c, --config [path]', 'Path to config file.', './config/main.json')
-  .action(restoreDB.do); 
-  
+  .action(restoreDB.do);
+
 program
   .command('rotate-keys')
   .description('Rotate the nodes keys.')
   .option('-c, --config [path]', 'Path to config file.', './config/main.json')
-  .action(rotateKeys.do);   
+  .action(rotateKeys.do);
 
 program.allowUnknownOption(false);
 

--- a/src/lib/actions/unlock.js
+++ b/src/lib/actions/unlock.js
@@ -1,0 +1,28 @@
+const chalk = require('chalk');
+const process = require('process');
+
+const config = require('../config.js');
+const { Platform } = require('../platform.js');
+
+
+module.exports = {
+  do: async (cmd) => {
+    const cfg = config.read(cmd.config);
+
+    console.log(chalk.yellow('Unlocking platform states...'));
+    const platform = new Platform(cfg);
+    try {
+      // Node this cmd is not very well supported, as this should not be needed if the tf process is executed cleanly.
+      // In case the tensorflow actions fails due to not being able to acquire the locks because it unexpectedly exited
+      // before, the locks can be released with this command. The `lockId`s in question need to be added to the node's
+      // config.
+      //
+      // IMPORTANT: Only use this when you are sure the lock is not used by another user.
+      await platform.unlock();
+    } catch (e) {
+      console.log(chalk.red(`Could not unlock platform: ${e.message}`));
+      process.exit(-1);
+    }
+    console.log(chalk.green('Done'));
+  }
+}

--- a/src/lib/clients/ansible.js
+++ b/src/lib/clients/ansible.js
@@ -108,6 +108,10 @@ class Ansible {
       data.dbSnapshotChecksum = this.config.collators.dbSnapshot.checksum;
     }
 
+    console.log(`[Ansible] Origin Config: ${JSON.stringify(origin, null, 2)}`)
+    console.log(`[Ansible] Origin Config: ${JSON.stringify(target, null, 2)}`)
+    console.log(`[Ansible] Origin Config: ${JSON.stringify(data, null, 2)}`)
+
     tpl.create(origin, target, data);
 
     return target;

--- a/src/lib/clients/ansible.js
+++ b/src/lib/clients/ansible.js
@@ -54,8 +54,6 @@ class Ansible {
       parachainAdditionalPublicFlags = this.config.publicNodes.additionalFlags;
     }
 
-    console.log(`[Ansible] Added public nodes: ${JSON.stringify(publicNodes)}`)
-
     const data = {
       project: this.config.project,
 
@@ -108,9 +106,9 @@ class Ansible {
       data.dbSnapshotChecksum = this.config.collators.dbSnapshot.checksum;
     }
 
-    console.log(`[Ansible] Origin Config: ${JSON.stringify(origin, null, 2)}`)
-    console.log(`[Ansible] Origin Config: ${JSON.stringify(target, null, 2)}`)
-    console.log(`[Ansible] Origin Config: ${JSON.stringify(data, null, 2)}`)
+    console.log(`[Ansible] Origin: ${JSON.stringify(origin, null, 2)}`)
+    console.log(`[Ansible] Target: ${JSON.stringify(target, null, 2)}`)
+    console.log(`[Ansible] Data: ${JSON.stringify(data, null, 2)}`)
 
     tpl.create(origin, target, data);
 

--- a/src/lib/clients/ansible.js
+++ b/src/lib/clients/ansible.js
@@ -54,6 +54,8 @@ class Ansible {
       parachainAdditionalPublicFlags = this.config.publicNodes.additionalFlags;
     }
 
+    console.log(`[Ansible] Added public nodes: ${JSON.stringify(publicNodes)}`)
+
     const data = {
       project: this.config.project,
 

--- a/src/lib/platform.js
+++ b/src/lib/platform.js
@@ -31,6 +31,10 @@ class Platform {
     return this.tf.clean();
   }
 
+  async unlock() {
+    return this.tf.unlock();
+  }
+
   async _extractOutput(type, nodeSet) {
     const output = [];
     await asyncUtils.forEach(nodeSet, async (node, index) => {

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -1,5 +1,5 @@
-resource "google_compute_firewall" "ssh-p2p-{{ name }}" {
-  name    = "ssh-p2p-proxy-{{ name }}"
+resource "google_compute_firewall" "ssh-p2p-wss-{{ name }}" {
+  name    = "ssh-p2p-wss-proxy-{{ name }}"
   network = "default"
 
   allow {
@@ -60,7 +60,7 @@ resource "google_compute_instance" "main-{{ name }}" {
     }
   }
 
-  depends_on = [google_compute_firewall.ssh-p2p-{{ name }}, google_compute_firewall.vpn-{{ name }}]
+  depends_on = [google_compute_firewall.ssh-p2p-wss-{{ name }}, google_compute_firewall.vpn-{{ name }}]
 
   service_account {
     scopes = ["compute-ro"]

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -4,7 +4,7 @@ resource "google_compute_firewall" "ssh-p2p-{{ name }}" {
 
   allow {
     protocol = "tcp"
-    ports    = ["22", "30333", "80"]
+    ports    = ["22", "30333", "80", "443"]
   }
 
   source_ranges = ["0.0.0.0/0"]

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -4,7 +4,7 @@ resource "google_compute_firewall" "ssh-p2p-wss-{{ name }}" {
 
   allow {
     protocol = "tcp"
-    ports    = ["22", "30333", "80", "443"]
+    ports    = ["22", "30333", "30334","80", "443"]
   }
 
   source_ranges = ["0.0.0.0/0"]

--- a/tpl/ansible_inventory
+++ b/tpl/ansible_inventory
@@ -20,6 +20,7 @@ ansible_user={{ this.sshUser }}
 telemetryUrl={{ ../collatorTelemetryUrl }}
 loggingFilter='{{{ ../collatorLoggingFilter }}}'
 nodeName={{ this.nodeName }}
+enable_reverse_proxy=True
 is_public=True
 
 {{/each}}

--- a/tpl/ansible_inventory
+++ b/tpl/ansible_inventory
@@ -21,7 +21,6 @@ telemetryUrl={{ ../collatorTelemetryUrl }}
 loggingFilter='{{{ ../collatorLoggingFilter }}}'
 nodeName={{ this.nodeName }}
 ip_address={{ this.ipAddress }}
-is_collator=True
 is_public=True
 
 {{/each}}

--- a/tpl/ansible_inventory
+++ b/tpl/ansible_inventory
@@ -10,11 +10,28 @@ nodeName={{ this.nodeName }}
 
 {{/each}}
 
+{{#each publicNodes }}
+[publicNode_{{@index}}]
+{{ this.ipAddress }}
+
+[publicNode_{{@index}}:vars]
+ansible_user={{ this.sshUser }}
+telemetryUrl={{ ../collatorTelemetryUrl }}
+loggingFilter='{{{ ../collatorLoggingFilter }}}'
+nodeName={{ this.nodeName }}
+
+{{/each}}
+
+
 [collator:children]
 {{#each collators }}
 collator_{{@index}}
 {{/each}}
 
+[publicNode:children]
+{{#each publicNodes }}
+publicNode_{{@index}}
+{{/each}}
 
 [all:vars]
 project={{ project }}

--- a/tpl/ansible_inventory
+++ b/tpl/ansible_inventory
@@ -7,6 +7,7 @@ ansible_user={{ this.sshUser }}
 telemetryUrl={{ ../collatorTelemetryUrl }}
 loggingFilter='{{{ ../collatorLoggingFilter }}}'
 nodeName={{ this.nodeName }}
+is_collator=True
 
 {{/each}}
 
@@ -19,7 +20,7 @@ ansible_user={{ this.sshUser }}
 telemetryUrl={{ ../collatorTelemetryUrl }}
 loggingFilter='{{{ ../collatorLoggingFilter }}}'
 nodeName={{ this.nodeName }}
-isPublicNode=true
+is_public=True
 
 {{/each}}
 

--- a/tpl/ansible_inventory
+++ b/tpl/ansible_inventory
@@ -20,7 +20,7 @@ ansible_user={{ this.sshUser }}
 telemetryUrl={{ ../collatorTelemetryUrl }}
 loggingFilter='{{{ ../collatorLoggingFilter }}}'
 nodeName={{ this.nodeName }}
-enable_reverse_proxy=True
+is_collator=True
 is_public=True
 
 {{/each}}

--- a/tpl/ansible_inventory
+++ b/tpl/ansible_inventory
@@ -19,6 +19,7 @@ ansible_user={{ this.sshUser }}
 telemetryUrl={{ ../collatorTelemetryUrl }}
 loggingFilter='{{{ ../collatorLoggingFilter }}}'
 nodeName={{ this.nodeName }}
+isPublicNode=true
 
 {{/each}}
 

--- a/tpl/ansible_inventory
+++ b/tpl/ansible_inventory
@@ -20,6 +20,7 @@ ansible_user={{ this.sshUser }}
 telemetryUrl={{ ../collatorTelemetryUrl }}
 loggingFilter='{{{ ../collatorLoggingFilter }}}'
 nodeName={{ this.nodeName }}
+ip_address={{ this.ipAddress }}
 is_collator=True
 is_public=True
 


### PR DESCRIPTION
Uses a self-signed certificate for now.

Successfully connected to the public node parachain behind and nginx ssl setup. As the certificate is self-signed for now, it needs to be whitelisted by the browser to be able to connect to the node. This is done by trying to connect to `https://<public_node_ip>` in a browser window and going through the dialog.

The wss reverse proxy-setup has been configured according to the guide: https://wiki.polkadot.network/docs/maintain-wss